### PR TITLE
Guard against division by zero when calculating R-squared

### DIFF
--- a/src/Regression.php
+++ b/src/Regression.php
@@ -244,7 +244,12 @@ class Regression
     public function getRSquared()
     {
         if (is_null($this->r2)) {
-            $this->r2 = 1 - $this->getSumSquaredError() / $this->getMeanSquaredError();
+            $meanSquaredError = $this->getMeanSquaredError();
+            if ($meanSquaredError === 0) {
+                $this->r2 = 0;
+            } else {
+                $this->r2 = 1 - $this->getSumSquaredError() / $meanSquaredError;
+            }
         }
         
         return $this->r2;

--- a/tests/ZeroCorrelationRegressionTest.php
+++ b/tests/ZeroCorrelationRegressionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use mcordingley\Regression\Regression;
+use mcordingley\Regression\RegressionAlgorithm\LinearLeastSquares;
+
+class ZeroCorrelationRegressionTest extends PHPUnit_Framework_TestCase
+{
+    protected $regression;
+    
+    public function __construct($name = null, array $data = array(), $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        
+        $this->regression = new Regression(new LinearLeastSquares);
+
+        $this->regression->addData(1, [1, 1]);
+        $this->regression->addData(1, [1, 2]);
+        $this->regression->addData(1, [1, 3]);
+    }
+    
+    public function testCoefficients()
+    {
+        $coefficients = $this->regression->getCoefficients();
+        
+        $this->assertEquals(1.0, round($coefficients[0], 1));
+        $this->assertEquals(0.0, round($coefficients[1], 1));
+    }
+    
+    public function testPredict()
+    {
+        $this->assertEquals(1, round($this->regression->predict([1, 4])));
+    }
+    
+    public function testRSquaredForZeroCorrelation()
+    {
+        $this->assertEquals(0.0, round($this->regression->getRSquared(), 1));
+    }
+}


### PR DESCRIPTION
This can occur for example when all points lie on a horizontal line,
thus having no correlation nor any mean squared error

Please review whether the test is written properly and if the guard is OK.
